### PR TITLE
Remove printf on reset_config

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,8 +62,7 @@ void reset(){
 }
 
 void reset_config() {
-  printf("resetting config...\n");
-  WiFiManager wifiManager;
+  WiFiManager wifiManager(Serial1);  // Send debug on Serial1
   wifiManager.resetSettings();
   reset();
 }


### PR DESCRIPTION
It seems to be redundant with data emitted by WiFiManager (until setDebugOutput is not set to false), which I redirect on Serial1, not on Serial anymore.