### PR TITLE
Exclude time for status server in max loop duration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,7 +143,6 @@ bool handleStatusServerRequests() {
     client.printf("version: %s\r\n", AUTO_VERSION);
     client.flush();
     client.stop();
-    maxLoopDuration = 0;
   }
   return true;
 }
@@ -180,7 +179,12 @@ void loop() {
   }
 
   // Check if new client on the status server
-  handleStatusServerRequests();
+  if (handleStatusServerRequests()) {
+    // exclude handleStatusServerRequests from maxLoopDuration calculation
+    // as it skews the typical loop duration and set maxLoopDuration to 0
+    loop_duration();
+    maxLoopDuration = 0;
+  }
 
   // Check if there are any new clients on the eBUS servers
   if (handleNewClient(wifiServer, serverClients)){


### PR DESCRIPTION
This change gives a better view on the typical max loop duration. Without this change, the time needed to handle the status server request is included in the max loop duration, which makes the max loop duration useless. 
